### PR TITLE
More Testing Setup for the Avalonia MVVM Project

### DIFF
--- a/Khartyko.InsigniaCreator/Khartyko.InsigniaCreator.MainApp/Program.cs
+++ b/Khartyko.InsigniaCreator/Khartyko.InsigniaCreator.MainApp/Program.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Khartyko.InsigniaCreator.MainApp;
 
-class Program
+public class Program
 {
     // Initialization code. Don't use any Avalonia, third-party APIs or any
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized

--- a/Khartyko.InsigniaCreator/Testing/Khartyko.InsigniaCreator.MainApp.Testing/AppTests.cs
+++ b/Khartyko.InsigniaCreator/Testing/Khartyko.InsigniaCreator.MainApp.Testing/AppTests.cs
@@ -1,0 +1,20 @@
+using Avalonia.Controls.ApplicationLifetimes;
+using Khartyko.InsigniaCreator.MainApp.ViewModels;
+namespace Khartyko.InsigniaCreator.MainApp.Testing;
+
+public class AppTests
+{
+	[Fact]
+	public void Construct_Succeeds()
+	{
+		var app = new App();
+		
+		/*
+		 * Considering the app isn't configured, especially with how
+		 *	Avalonia UI sets it up, there's only so much that can be tested
+		 */
+		
+		Assert.NotNull(app);
+		Assert.Equal("Avalonia Application", app.Name);
+	}
+}

--- a/Khartyko.InsigniaCreator/Testing/Khartyko.InsigniaCreator.MainApp.Testing/MainWindowViewModelTests.cs
+++ b/Khartyko.InsigniaCreator/Testing/Khartyko.InsigniaCreator.MainApp.Testing/MainWindowViewModelTests.cs
@@ -1,0 +1,14 @@
+using Khartyko.InsigniaCreator.MainApp.ViewModels;
+
+namespace Khartyko.InsigniaCreator.MainApp.Testing;
+
+public class MainWindowViewModelTests
+{
+	[Fact]
+	public void Construct_Succeeds()
+	{
+		var mainWindowViewModel = new MainWindowViewModel();
+		
+		Assert.NotNull(mainWindowViewModel);
+	}
+}

--- a/Khartyko.InsigniaCreator/Testing/Khartyko.InsigniaCreator.MainApp.Testing/ProgramTests.cs
+++ b/Khartyko.InsigniaCreator/Testing/Khartyko.InsigniaCreator.MainApp.Testing/ProgramTests.cs
@@ -1,0 +1,22 @@
+using Avalonia;
+
+namespace Khartyko.InsigniaCreator.MainApp.Testing;
+
+public class ProgramTests
+{
+	[Fact]
+	public void BuildAvaloniaApp_Succeeds()
+	{
+		AppBuilder appBuilder = Program.BuildAvaloniaApp();
+		
+		/*
+		 * As is the case in multiple spots, the core of this
+		 *	project cannot be tested, but here's what I can,
+		 *	that I know of.
+		 */
+		
+		Assert.NotNull(appBuilder);
+		Assert.NotNull(appBuilder.ApplicationType);
+		Assert.Equal(typeof(App), appBuilder.ApplicationType);
+	}
+}

--- a/Khartyko.InsigniaCreator/Testing/Khartyko.InsigniaCreator.MainApp.Testing/ViewLocatorTests.cs
+++ b/Khartyko.InsigniaCreator/Testing/Khartyko.InsigniaCreator.MainApp.Testing/ViewLocatorTests.cs
@@ -8,6 +8,8 @@ internal class InvalidViewModel : ViewModelBase
 
 public class ViewLocatorTests
 {
+	#region Build
+
 	[Fact]
 	public void Build_Succeeds()
 	{
@@ -52,4 +54,37 @@ public class ViewLocatorTests
 		
 		Assert.Equal(expectedText, textBlock.Text);
 	}
+
+	#endregion Build
+
+	#region Match
+
+	[Fact]
+	public void Match_Succeeds()
+	{
+		var testViewModel = new TestViewModel();
+		var viewLocator = new ViewLocator();
+		
+		Assert.True(viewLocator.Match(testViewModel));
+	}
+
+	[Fact]
+	public void Match_NullObject_Fails()
+	{
+		object? nullObject = null;
+		var viewLocator = new ViewLocator();
+		
+		Assert.False(viewLocator.Match(nullObject));
+	}
+
+	[Fact]
+	public void Match_InvalidObject_Fails()
+	{
+		object? invalidObject = new object();
+		var viewLocator = new ViewLocator();
+		
+		Assert.False(viewLocator.Match(invalidObject));
+	}
+
+	#endregion Match
 }


### PR DESCRIPTION
After discovering where I could find the uncovered lines overall in SonarCloud's website, and not just for a branch/pull request, I am able to set up more testing, where possible.